### PR TITLE
feat/config/swagger-api; UserRequestDTO에 Swagger 명세 추가

### DIFF
--- a/src/main/java/com/book/book_log/dto/UserRequestDTO.java
+++ b/src/main/java/com/book/book_log/dto/UserRequestDTO.java
@@ -1,5 +1,6 @@
 package com.book.book_log.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,7 +8,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserRequestDTO {
     private String username;
+
+    @Schema(description = "성별 (허용값: MALE, FEMALE, UNKNOWN)", example = "MALE", allowableValues = {"MALE", "FEMALE", "UNKNOWN"})
     private String gender;
+
+    @Schema(description = "연령대 (허용값: AGE_10S, AGE_20S, AGE_30S, AGE_40S, AGE_50S, AGE_60_PLUS)", example = "AGE_20S", allowableValues = {"AGE_10S", "AGE_20S", "AGE_30S", "AGE_40S", "AGE_50S", "AGE_60_PLUS"})
     private String ageGroup;
 
     public UserRequestDTO(String username, String gender, String ageGroup) {


### PR DESCRIPTION
- UserRequestDTO 필드에 @Schema 어노테이션 추가
  - gender: 허용값 및 예제 추가(MALE, FEMALE, UNKNOWN)
  - ageGroup: 허용값 및 예제 추가(AGE_10S, AGE_20S, AGE_30S, AGE_40S, AGE_50S, AGE_60_PLUS)
- Swagger UI에서 API 문서화 개선
  - 필드 설명 및 허용값 명시