### PR TITLE
refactor/back/user-module; User 엔티티에서 email 필드 제거 및 관련 코드 정리

### DIFF
--- a/src/main/java/com/book/book_log/controller/UserController.java
+++ b/src/main/java/com/book/book_log/controller/UserController.java
@@ -8,8 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
-
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -51,13 +49,5 @@ public class UserController {
     public ResponseEntity<Boolean> checkUsername(@RequestParam String username) {
         boolean isAvailable = uSvc.isUsernameAvailable(username);
         return ResponseEntity.ok(isAvailable);
-    }
-
-    // 이메일 기반 사용자 조회
-    @GetMapping("/email/{email}")
-    public ResponseEntity<UserResponseDTO> findUserByEmail(@PathVariable String email) {
-        Optional<UserResponseDTO> user = uSvc.findUserByEmail(email);
-        return user.map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }
 }

--- a/src/main/java/com/book/book_log/entity/User.java
+++ b/src/main/java/com/book/book_log/entity/User.java
@@ -31,9 +31,6 @@ public class User {
     @Column(length = 20)
     private AgeGroup age_group;
 
-    @Column(length = 100, unique = true)
-    private String email;
-
 //    // 소셜 로그인 관련 필드(나중에 구현)
 //    @Column(length = 20, nullable = false)
 //    private String oauth_provider;

--- a/src/main/java/com/book/book_log/repository/UserRepository.java
+++ b/src/main/java/com/book/book_log/repository/UserRepository.java
@@ -3,12 +3,7 @@ package com.book.book_log.repository;
 import com.book.book_log.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface UserRepository extends JpaRepository<User, String> {
-    // 이메일로 사용자 조회(소셜 로그인을 구현하기 위해 필요함)
-    Optional<User> findByEmail(String email);
-
     // 닉네임 중복 확인
     boolean existsByUsername(String username);
 }

--- a/src/main/java/com/book/book_log/service/UserService.java
+++ b/src/main/java/com/book/book_log/service/UserService.java
@@ -11,8 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -64,12 +62,6 @@ public class UserService {
     // 닉네임 중복 확인
     public boolean isUsernameAvailable(String username) {
         return !uRepo.existsByUsername(username);
-    }
-
-    // 이메일 기반 사용자 조회 (소셜 로그인에 사용됨)
-    public Optional<UserResponseDTO> findUserByEmail(String email) {
-        return uRepo.findByEmail(email)
-                .map(this::toResponseDTO); // User -> DTO 변환
     }
 
     // DTO 변환 메서드


### PR DESCRIPTION
- 기존 email 필드가 불필요함에 따라 ERD와 코드의 불필요한 의존성을 제거
- User 엔티티에서 email 필드 삭제
- UserRepository에서 이메일로 사용자 조회 메서드 제거
- UserService에서 이메일 기반 사용자 조회 로직 제거
- 이메일 필드 제거에 따른 관련 주석 삭제 및 코드 정리
- User 관련 테스트 코드에는 영향 없음 (email 관련 로직 미포함)